### PR TITLE
Emulate timeline API locally for emulator support

### DIFF
--- a/pypkjs/javascript/pebble.py
+++ b/pypkjs/javascript/pebble.py
@@ -47,7 +47,8 @@ class Pebble(events.EventSourceMixin, v8.JSClass):
             _make_proxies(this, _internal_pebble,
                 ['sendAppMessage', 'showSimpleNotificationOnPebble', 'getAccountToken', 'getWatchToken',
                 'addEventListener', 'removeEventListener', 'openURL', 'getTimelineToken', 'timelineSubscribe',
-                'timelineUnsubscribe', 'timelineSubscriptions', 'getActiveWatchInfo', 'appGlanceReload']);
+                'timelineUnsubscribe', 'timelineSubscriptions', 'getActiveWatchInfo', 'appGlanceReload',
+                'insertTimelinePin', 'deleteTimelinePin']);
             this.platform = 'pypkjs';
         })();
         """)
@@ -245,6 +246,42 @@ class Pebble(events.EventSourceMixin, v8.JSClass):
             if callable(success):
                 self.runtime.enqueue(success, subs)
         self.runtime.group.spawn(go)
+
+    def insertTimelinePin(self, pin):
+        """Insert a timeline pin directly, without going through the timeline web API."""
+        import json
+        import datetime
+        import uuid as uuid_mod
+
+        if isinstance(pin, str):
+            pin = json.loads(pin)
+        else:
+            # Convert V8 JSObject to Python dict via JSON round-trip
+            pin = json.loads(self.runtime.context.eval("JSON.stringify")(pin))
+
+        pin_id = str(pin.get('id', uuid_mod.uuid4()))
+        guid = uuid_mod.uuid5(uuid_mod.NAMESPACE_DNS, '%s.pin.developer.getpebble.com' % pin_id)
+        now = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+        pin['guid'] = str(guid)
+        pin['createTime'] = now
+        pin['updateTime'] = now
+        pin['topicKeys'] = pin.get('topicKeys', [])
+        pin['source'] = 'sdk'
+        pin['dataSource'] = 'sandbox-uuid:%s' % self.uuid
+
+        logger.info("insertTimelinePin: '%s' (guid=%s) for app %s", pin_id, guid, self.uuid)
+        self.runtime.runner.timeline.handle_pin_create(pin, manual=True)
+
+    def deleteTimelinePin(self, pin_id):
+        """Delete a timeline pin directly by its ID."""
+        import uuid as uuid_mod
+
+        guid = uuid_mod.uuid5(uuid_mod.NAMESPACE_DNS, '%s.pin.developer.getpebble.com' % pin_id)
+        logger.info("deleteTimelinePin: '%s' (guid=%s)", pin_id, guid)
+        try:
+            self.runtime.runner.timeline.handle_pin_delete({'guid': str(guid)})
+        except Exception:
+            pass  # Pin may not exist
 
     def _infer_installed_platform(self):
         available_prefixes = self.runtime.pbw.prefixes

--- a/pypkjs/javascript/pebble.py
+++ b/pypkjs/javascript/pebble.py
@@ -204,16 +204,10 @@ class Pebble(events.EventSourceMixin, v8.JSClass):
     def _get_timeline_token(self):
         if self._timeline_token is not None:
             return self._timeline_token
-        result = requests.get(self.runtime.runner.urls.sandbox_token % self.uuid,
-                              headers={'Authorization': 'Bearer %s' % self.runtime.runner.oauth_token})
-        if result.status_code == 404:
-            raise TokenException("No token available; make sure the app is timeline enabled "
-                                 "and this user authorised in the developer portal.")
-        elif result.status_code == 401:
-            raise TokenException("User login rejected; make sure you are logged in to the SDK.")
-        result.raise_for_status()
-        logger.debug("get_timeline_token result: %s", result.json())
-        self._timeline_token = result.json()['token']
+        # Return a dummy token for local timeline emulation.
+        # The original Pebble timeline servers are gone; CoreApp uses the same approach.
+        self._timeline_token = "emulated-dummy-token"
+        logger.info("Using emulated timeline token for app %s", self.uuid)
         return self._timeline_token
 
     def getTimelineToken(self, success=None, failure=None):
@@ -233,21 +227,10 @@ class Pebble(events.EventSourceMixin, v8.JSClass):
         self.runtime.group.spawn(go)
 
     def _do_timeline_thing(self, method, topic, success, failure):
-        try:
-            token = self._get_timeline_token()
-            result = requests.request(method, self.runtime.runner.urls.manage_subscription % urllib.parse.quote(topic, safe=''),
-                                      headers={'X-User-Token': token})
-            result.raise_for_status()
-        except (requests.RequestException, TokenException) as e:
-            if callable(failure):
-                self.runtime.enqueue(failure, str(e))
-        except Exception as e:
-            traceback.print_exc()
-            if callable(failure):
-                self.runtime.enqueue(failure, "Internal failure.")
-        else:
-            if callable(success):
-                self.runtime.enqueue(success)
+        # Local emulation: subscriptions are no-ops
+        logger.info("Timeline subscription %s for topic '%s' (emulated locally)", method, topic)
+        if callable(success):
+            self.runtime.enqueue(success)
 
     def timelineSubscribe(self, topic, success=None, failure=None):
         self.runtime.group.spawn(self._do_timeline_thing, "POST", topic, success, failure)
@@ -257,21 +240,10 @@ class Pebble(events.EventSourceMixin, v8.JSClass):
 
     def timelineSubscriptions(self, success=None, failure=None):
         def go():
-            try:
-                token = self._get_timeline_token()
-                result = requests.get(self.runtime.runner.urls.app_subscription_list, headers={'X-User-Token': token})
-                result.raise_for_status()
-                subs = v8.JSArray(result.json()['topics'])
-            except (requests.RequestException, TokenException) as e:
-                if callable(failure):
-                    self.runtime.enqueue(failure, str(e))
-            except Exception:
-                traceback.print_exc()
-                if callable(failure):
-                    self.runtime.enqueue(failure, "Internal failure.")
-            else:
-                if callable(success):
-                    self.runtime.enqueue(success, subs)
+            # Local emulation: return empty subscription list
+            subs = v8.JSArray([])
+            if callable(success):
+                self.runtime.enqueue(success, subs)
         self.runtime.group.spawn(go)
 
     def _infer_installed_platform(self):

--- a/pypkjs/javascript/xhr.py
+++ b/pypkjs/javascript/xhr.py
@@ -60,6 +60,9 @@ class XHRExtension:
             }
         """)
 
+_TIMELINE_API_HOSTS = {'timeline-api.rebble.io', 'timeline-api.getpebble.com'}
+
+
 class XMLHttpRequest(events.EventSourceMixin):
     UNSENT = 0
     OPENED = 1
@@ -126,8 +129,104 @@ class XMLHttpRequest(events.EventSourceMixin):
             raise Exception(exception)
         self._trigger_async_event("readystatechange")
 
+    def _is_timeline_api_request(self):
+        """Check if this request targets a timeline pin API endpoint."""
+        if self._request is None or self._request.url is None:
+            return False
+        from urllib.parse import urlparse
+        parsed = urlparse(self._request.url)
+        return (parsed.hostname in _TIMELINE_API_HOSTS
+                and parsed.path is not None
+                and parsed.path.lower().startswith('/v1/user/pins'))
+
+    def _handle_timeline_api_request(self):
+        """Handle a timeline API request locally via BlobDB instead of hitting the dead server."""
+        import json
+        import datetime
+        import uuid as uuid_mod
+        import logging
+        from urllib.parse import urlparse, unquote
+
+        tl_logger = logging.getLogger('pypkjs.javascript.xhr.timeline')
+        method = self._request.method.upper()
+        parsed = urlparse(self._request.url)
+        path = parsed.path
+
+        timeline = self._runtime.runner.timeline
+        app_uuid = str(self._runtime.runner.running_uuid)
+
+        if method in ('PUT', 'POST'):
+            body = self._request.data
+            if body is None:
+                raise Exception("No body provided for timeline pin insert")
+            pin = json.loads(body) if isinstance(body, str) else json.loads(body.decode('utf-8'))
+
+            # Extract pin_id from URL path or body
+            path_after_pins = path.split('/v1/user/pins/')[-1].strip('/')
+            if path_after_pins:
+                pin_id = unquote(path_after_pins)
+            elif 'id' in pin:
+                pin_id = str(pin['id'])
+            else:
+                raise Exception("No pin id found in URL or body")
+
+            # Convert to web pin format (same as InsertPinCommand in pebble_tool/commands/timeline.py)
+            guid = uuid_mod.uuid5(uuid_mod.NAMESPACE_DNS, '%s.pin.developer.getpebble.com' % pin_id)
+            now = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+            pin['guid'] = str(guid)
+            pin['createTime'] = now
+            pin['updateTime'] = now
+            pin['topicKeys'] = pin.get('topicKeys', [])
+            pin['source'] = 'sdk'
+            pin['dataSource'] = 'sandbox-uuid:%s' % app_uuid
+
+            tl_logger.info("Inserting local timeline pin '%s' (guid=%s) for app %s", pin_id, guid, app_uuid)
+            timeline.handle_pin_create(pin, manual=True)
+
+        elif method == 'DELETE':
+            path_after_pins = path.split('/v1/user/pins/')[-1].strip('/')
+            if not path_after_pins:
+                raise Exception("No pin id in DELETE URL")
+            pin_id = unquote(path_after_pins)
+            guid = uuid_mod.uuid5(uuid_mod.NAMESPACE_DNS, '%s.pin.developer.getpebble.com' % pin_id)
+            tl_logger.info("Deleting local timeline pin '%s' (guid=%s)", pin_id, guid)
+            try:
+                timeline.handle_pin_delete({'guid': str(guid)})
+            except Exception:
+                pass  # Pin may not exist, which is fine for DELETE
+
+        else:
+            raise Exception("Unsupported method %s for timeline API" % method)
+
+        # Simulate successful response
+        self.readyState = self.DONE
+        self.status = 200
+        self.statusText = 'OK'
+        self.responseText = '{}'
+        if self.responseType == "json":
+            self.response = {}
+        else:
+            self.response = self.responseText
+
     def _do_send(self):
         self._sent = True
+
+        # Intercept timeline API requests and handle locally
+        if self._is_timeline_api_request():
+            try:
+                self._handle_timeline_api_request()
+                self._trigger_async_event("load", ProgressEvent, (self._runtime,))
+            except Exception as e:
+                self.status = 500
+                self.statusText = str(e)
+                self.readyState = self.DONE
+                self.responseText = str(e)
+                self.response = self.responseText
+            finally:
+                self._trigger_async_event("loadend", ProgressEvent, (self._runtime,))
+                self._trigger_async_event("readystatechange")
+            return
+
         req = self._session.prepare_request(self._request)
         try:
             if self.timeout:

--- a/pypkjs/runner/__init__.py
+++ b/pypkjs/runner/__init__.py
@@ -120,9 +120,8 @@ class Runner(object):
     def run(self):
         self.logger.info('Connecting to pebble')
         greenlet = self.pebble.connect()
-        # if self.pebble.timeline_is_supported:
-        #     self.timeline.continuous_sync()
-        #     self.timeline.do_maintenance()
+        # continuous_sync() deliberately NOT enabled -- the remote server is dead.
+        self.timeline.do_maintenance()
         greenlet.join()
 
     @property

--- a/pypkjs/runner/websocket.py
+++ b/pypkjs/runner/websocket.py
@@ -64,9 +64,9 @@ class WebsocketRunner(Runner):
         pebble_greenlet = self.pebble.connect()
         self.pebble.pebble.register_raw_inbound_handler(self._handle_inbound)
         self.pebble.pebble.register_raw_outbound_handler(self._handle_outbound)
-        # if self.pebble.timeline_is_supported:
-        #     self.timeline.continuous_sync()
-        #     self.timeline.do_maintenance()
+        # continuous_sync() deliberately NOT enabled -- the remote server is dead.
+        # do_maintenance() handles sending pending pins and cleanup.
+        self.timeline.do_maintenance()
         logging.getLogger().addHandler(WebsocketLogHandler(self, level=logging.WARNING))
         if self.ssl_root is not None:
             ssl_args = {


### PR DESCRIPTION
## Summary

- `Pebble.getTimelineToken()` now returns a dummy token instead of hitting the dead `timeline-sync.getpebble.com` server
- XHR requests to `timeline-api.rebble.io` and `timeline-api.getpebble.com` are intercepted and handled locally via the existing `PebbleTimeline` + BlobDB infrastructure — pins are inserted directly into the watch timeline
- Added `Pebble.insertTimelinePin(pin)` and `Pebble.deleteTimelinePin(id)` direct methods matching CoreApp's `PrivatePKJSInterface` ([coredevices/CoreApp@8471442](https://github.com/coredevices/CoreApp/commit/847144276745040d92cc07a744cb5b07a66639aa)), allowing JS apps to manage timeline pins without going through the XHR/timeline API flow
- Timeline subscription methods (`timelineSubscribe`, `timelineUnsubscribe`, `timelineSubscriptions`) are stubbed as local no-ops
- Timeline maintenance loop is enabled for pin lifecycle management (sending pending pins, cleanup)

This mirrors the "Emulate Remote Timeline" approach already used by CoreApp (the Android companion app), which intercepts the same endpoints and stores pins locally.

Fixes https://forum.repebble.com/t/are-local-timeline-pins-already-workin-in-the-emulator/402

## How it works

### XHR interception (existing timeline API pattern)
1. JS app calls `Pebble.getTimelineToken()` → receives `"emulated-dummy-token"`
2. JS app PUTs/POSTs pin JSON to `https://timeline-api.rebble.io/v1/user/pins/{pinId}` via XHR
3. `XMLHttpRequest._do_send()` detects the timeline API host and intercepts the request
4. Pin JSON is converted to the web pin format (same as `pebble insert-pin`) and passed to `PebbleTimeline.handle_pin_create()`
5. Pin is serialized and inserted into the watch via BlobDB
6. JS app receives a `200 OK` response as if the real server handled it

### Direct methods (new, matches CoreApp)
1. JS app calls `Pebble.insertTimelinePin(pin)` with a pin object or JSON string
2. Pin is converted to web pin format and inserted via `PebbleTimeline.handle_pin_create()`
3. `Pebble.deleteTimelinePin(id)` removes a pin by its string ID

## Test plan

- [ ] Build a PBW with JS that calls `Pebble.getTimelineToken()` then PUTs a pin to `https://timeline-api.rebble.io/v1/user/pins/{id}` — verify token is received and pin insert returns status 200
- [ ] Test `Pebble.insertTimelinePin({id: "test", time: "...", layout: {type: "genericPin", title: "Test"}})` — verify pin appears in timeline DB
- [ ] Test `Pebble.deleteTimelinePin("test")` — verify no error for missing pins
- [ ] Check the timeline database has pins: `sqlite3 "<persist_dir>/timeline.db" "SELECT * FROM timelineitem;"`
- [ ] Verify `pebble insert-pin` (WebSocket path) still works alongside the new methods

🤖 Generated with [Claude Code](https://claude.com/claude-code)