### PR TITLE
Add geolocation spoofing with runtime coordinate updates

### DIFF
--- a/pypkjs/javascript/navigator/__init__.py
+++ b/pypkjs/javascript/navigator/__init__.py
@@ -10,7 +10,8 @@ class Navigator(object):
 
         self._runtime = runtime
 
-        runtime.register_syscall('__get_internal_location', lambda : Geolocation(runtime))
+        runtime.geolocation = Geolocation(runtime)
+        runtime.register_syscall('__get_internal_location', lambda: runtime.geolocation)
 
         runtime.run_js("""
         navigator = new (function() {

--- a/pypkjs/javascript/navigator/__init__.py
+++ b/pypkjs/javascript/navigator/__init__.py
@@ -9,7 +9,6 @@ class Navigator(object):
     def __init__(self, runtime):
 
         self._runtime = runtime
-        self._runtime = runtime
 
         runtime.register_syscall('__get_internal_location', lambda : Geolocation(runtime))
 

--- a/pypkjs/javascript/navigator/geolocation.py
+++ b/pypkjs/javascript/navigator/geolocation.py
@@ -15,6 +15,8 @@ Coordinates = lambda runtime, *args: v8.JSObject.create(runtime.context.locals.C
 class Geolocation(object):
     def __init__(self, runtime):
         self.runtime = runtime
+        self._watchers = {}
+        self._watch_counter = 0
 
         runtime.run_js("""
             Position = (function(coords, timestamp) {
@@ -59,8 +61,15 @@ class Geolocation(object):
         self.runtime.group.spawn(self._get_position, success, failure)
 
     def watchPosition(self, success, failure=None, options=None):
+        self._watch_counter += 1
+        watch_id = self._watch_counter
+        self._watchers[watch_id] = (success, failure)
         self.runtime.group.spawn(self._get_position, success, failure)
-        return 42
+        return watch_id
 
-    def clearWatch(self, thing):
-        pass
+    def clearWatch(self, watch_id):
+        self._watchers.pop(watch_id, None)
+
+    def notify_watchers(self):
+        for success, failure in tuple(self._watchers.values()):
+            self.runtime.group.spawn(self._get_position, success, failure)

--- a/pypkjs/javascript/navigator/geolocation.py
+++ b/pypkjs/javascript/navigator/geolocation.py
@@ -32,6 +32,11 @@ class Geolocation(object):
         """)
 
     def _get_position(self, success, failure):
+        latitude = self.runtime.runner.latitude
+        longitude = self.runtime.runner.longitude
+        if latitude is not None and longitude is not None:
+            self.runtime.enqueue(success, Position(self.runtime, Coordinates(self.runtime, longitude, latitude, 1000), round(time.time() * 1000)))
+            return
         try:
             resp = requests.get('https://api.ipify.org')
             resp.raise_for_status()

--- a/pypkjs/javascript/runtime.py
+++ b/pypkjs/javascript/runtime.py
@@ -45,6 +45,7 @@ class JSRuntime(object):
         self.runtime_id = JSRuntime.runtimeCount
         self.persist_dir = persist_dir
         self.block_private_addresses = block_private_addresses
+        self.geolocation = None
         JSRuntime.runtimeCount += 1
 
     def register_syscall(self, name, call_fn):

--- a/pypkjs/runner/__init__.py
+++ b/pypkjs/runner/__init__.py
@@ -143,6 +143,8 @@ class Runner(object):
     def set_location(self, latitude, longitude):
         self.latitude = latitude
         self.longitude = longitude
+        if self.js is not None and self.js.geolocation is not None:
+            self.js.enqueue(self.js.geolocation.notify_watchers)
 
     def log_output(self, message):
         raise NotImplemented

--- a/pypkjs/runner/__init__.py
+++ b/pypkjs/runner/__init__.py
@@ -28,11 +28,13 @@ from pypkjs.timeline.urls import URLManager
 class Runner(object):
     PBW = collections.namedtuple('PBW', ('uuid', 'src', 'manifest', 'layouts', 'prefixes'))
 
-    def __init__(self, qemu, pbws, persist_dir=None, oauth_token=None, layout_file=None, block_private_addresses=False):
+    def __init__(self, qemu, pbws, persist_dir=None, oauth_token=None, layout_file=None, block_private_addresses=False, latitude=None, longitude=None):
         self.qemu = qemu
         self.pebble = PebbleManager(qemu)
         self.persist_dir = persist_dir
         self.oauth_token = oauth_token
+        self.latitude = latitude
+        self.longitude = longitude
         self.pebble.handle_start = self.handle_start
         self.pebble.handle_stop = self.handle_stop
         # PBL-26034: Due to PBL-24009 we must be sure to respond to appmessages received with no JS running.
@@ -137,6 +139,10 @@ class Runner(object):
             self.log_output("No JS found, can't show configuration.")
             return
         self.js.do_config()
+
+    def set_location(self, latitude, longitude):
+        self.latitude = latitude
+        self.longitude = longitude
 
     def log_output(self, message):
         raise NotImplemented

--- a/pypkjs/runner/websocket.py
+++ b/pypkjs/runner/websocket.py
@@ -48,7 +48,7 @@ class Websocket(object):
 
 class WebsocketRunner(Runner):
     def __init__(self, qemu, pbws, port, token=None, ssl_root=None, persist_dir=None, oauth_token=None,
-                 layout_file=None, block_private_addresses=False):
+                 layout_file=None, block_private_addresses=False, latitude=None, longitude=None):
         self.port = port
         self.token = token
         self.requires_auth = (token is not None)
@@ -58,7 +58,8 @@ class WebsocketRunner(Runner):
         self.ssl_root = ssl_root
         self.config_callback = None
         super(WebsocketRunner, self).__init__(qemu, pbws, persist_dir=persist_dir, oauth_token=oauth_token,
-                                              layout_file=layout_file, block_private_addresses=block_private_addresses)
+                                              layout_file=layout_file, block_private_addresses=block_private_addresses,
+                                              latitude=latitude, longitude=longitude)
 
     def run(self):
         pebble_greenlet = self.pebble.connect()
@@ -141,6 +142,7 @@ class WebsocketRunner(Runner):
             0x0a: self.do_config_ws,
             0x0b: self.do_qemu_command,
             0x0c: self.do_timeline_command,
+            0x0d: self.do_set_location,
         }
 
         if opcode in opcode_handlers:
@@ -231,6 +233,13 @@ class WebsocketRunner(Runner):
             self.log_output("Pin insert failed: %s: %s" % (type(e).__name__, e))
             ws.send(bytearray([0x0c, 0x01]))
 
+    @must_auth
+    def do_set_location(self, ws, message):
+        if len(message) < 16:
+            return
+        latitude, longitude = struct.unpack('>dd', bytes(message[:16]))
+        self.set_location(latitude, longitude)
+
 
 class WebsocketLogHandler(logging.Handler):
     def __init__(self, ws_runner, *args, **kwargs):
@@ -259,6 +268,8 @@ def run_tool():
     parser.add_argument('--layout', default=None, help="Path to a firmware layout.json file on disk.")
     parser.add_argument('--debug', action='store_true', help="Very, very verbose debug spew.")
     parser.add_argument('--block-private-addresses', action='store_true', help="Disable access to private IPs.")
+    parser.add_argument('--latitude', type=float, default=None, help="Spoof GPS latitude.")
+    parser.add_argument('--longitude', type=float, default=None, help="Spoof GPS longitude.")
     parser.add_argument('pbws', nargs='*', help="Set of pbws.")
     args = parser.parse_args(sys.argv[1:])
     logging.basicConfig()
@@ -266,7 +277,8 @@ def run_tool():
         logging.getLogger().setLevel(logging.DEBUG)
     else:
         logging.getLogger().setLevel(logging.INFO)
-    runner = WebsocketRunner(args.qemu,args.pbws, args.port, token=args.token, ssl_root=args.ssl_root,
+    runner = WebsocketRunner(args.qemu, args.pbws, args.port, token=args.token, ssl_root=args.ssl_root,
                              persist_dir=args.persist, oauth_token=args.oauth, layout_file=args.layout,
-                             block_private_addresses=args.block_private_addresses)
+                             block_private_addresses=args.block_private_addresses,
+                             latitude=args.latitude, longitude=args.longitude)
     runner.run()


### PR DESCRIPTION
While building an app that relies on location, I found myself unable to test it reliably because the pebble tool currently doesn't support spoofed location. This is part 1 of the effort to add support for it, on the PyPKJS side.

This code was written by Sonnet 4.6, fully manually reviewed by me. I sign off on every line of the diff.