### PR TITLE
Drop numeric-key entries from AppMessage payload to match real Pebble

### DIFF
--- a/pypkjs/javascript/pebble.py
+++ b/pypkjs/javascript/pebble.py
@@ -121,7 +121,6 @@ class Pebble(events.EventSourceMixin, v8.JSClass):
                 value = v8.JSArray(list(v))
             else:
                 raise JSRuntimeException("?????")
-            d[str(k)] = value
             if k in app_keys:
                 d[str(app_keys[k])] = value
         e = events.Event(self.runtime, "AppMessage")


### PR DESCRIPTION
The PKJS `appmessage` event handler currently emits both the numeric and symbolic form of every key in `e.payload`. The real Pebble mobile app emits only the symbolic form, so any app that reads `e.payload[NUMERIC_KEY]` works under pypkjs (`pebble install --emulator`) and silently returns `undefined` on hardware (`pebble install --phone`). I hit this in production on a real watchapp.

Minimal Pebble app with both `emu.log` and `phone.log` captured against the same `.pbw`: https://github.com/ShinkoNet/pypkjs-appmsg-repro

Side-by-side from those logs (one key `MY_KEY=1`, value `"hello"`):

|                              | pypkjs (`--emulator basalt`)     | real Pebble app (`--phone`) |
| ---------------------------- | -------------------------------- | --------------------------- |
| `Object.keys(payload)`       | `[1, MY_KEY]`                    | `[MY_KEY]`                  |
| `payload[1]`                 | `"hello"`                        | `undefined`                 |
| `payload["MY_KEY"]`          | `"hello"`                        | `"hello"`                   |
| `JSON.stringify(payload)`    | `{"1":"hello","MY_KEY":"hello"}` | `{"MY_KEY":"hello"}`        |

This is a proposed fix: a one-line removal of the unconditional numeric-key assignment in `_handle_message`. This will make the emulator on parity with what a real device emits, but feel free to choose another solution if you want the device to work more like the emulator instead.